### PR TITLE
Setup default users (and roles)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
 
         <dependency>
             <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
         </dependency>
 

--- a/src/main/java/com/pproval/app/config/SecurityConfig.java
+++ b/src/main/java/com/pproval/app/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.pproval.app.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -8,6 +9,22 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+  @Override
+  protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+    auth.inMemoryAuthentication()
+        .withUser("editor")
+        .password("{noop}editor")
+        .roles("ADMIN", "USER", "EDITOR")
+        .and()
+        .withUser("reviewer")
+        .password("{noop}reviewer")
+        .roles("USER", "REVIEWER")
+        .and()
+        .withUser("submitter")
+        .password("{noop}submitter")
+        .roles("USER", "SUBMITTER");
+  }
+
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     http.authorizeRequests()

--- a/src/test/java/com/pproval/app/integration/InMemoryAuthTest.java
+++ b/src/test/java/com/pproval/app/integration/InMemoryAuthTest.java
@@ -1,0 +1,85 @@
+package com.pproval.app.integration;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest()
+@WebAppConfiguration
+public class InMemoryAuthTest {
+  @Autowired private WebApplicationContext ctx;
+
+  private MockMvc mock;
+
+  @Before
+  public void setup() {
+    mock =
+        MockMvcBuilders.<DefaultMockMvcBuilder>webAppContextSetup(ctx)
+            .apply(springSecurity())
+            .alwaysDo(print())
+            .build();
+  }
+
+  @Test
+  public void invalidLoginDenied() throws Exception {
+    mock.perform(formLogin().password("invalid"))
+        .andExpect(status().isFound())
+        .andExpect(redirectedUrl("/login?error"))
+        .andExpect(unauthenticated());
+
+    mock.perform(get("/login?error"))
+        .andExpect(content().string(containsString("Invalid credentials")));
+  }
+
+  @Test
+  public void loginAvailableForAll() throws Exception {
+    mock.perform(get("/login")).andExpect(status().isOk());
+  }
+
+  @Test
+  public void perform_LoginAsEditor() throws Exception {
+    mock.perform(formLogin().user("editor").password("editor"))
+        .andExpect(status().isFound())
+        .andExpect(redirectedUrl("/"))
+        .andExpect(authenticated().withUsername("editor").withRoles("ADMIN", "EDITOR", "USER"));
+  }
+
+  @Test
+  public void perform_LoginAsReviewer() throws Exception {
+    mock.perform(formLogin().user("reviewer").password("reviewer"))
+        .andExpect(status().isFound())
+        .andExpect(redirectedUrl("/"))
+        .andExpect(authenticated().withUsername("reviewer").withRoles("REVIEWER", "USER"));
+  }
+
+  @Test
+  public void perform_LoginAsSubmitter() throws Exception {
+    mock.perform(formLogin().user("submitter").password("submitter"))
+        .andExpect(status().isFound())
+        .andExpect(redirectedUrl("/"))
+        .andExpect(authenticated().withUsername("submitter").withRoles("SUBMITTER", "USER"));
+  }
+
+  @Test
+  public void requiresAuthentication() throws Exception {
+    mock.perform(get("/")).andExpect(redirectedUrl("http://localhost/login"));
+  }
+}


### PR DESCRIPTION
## Proposed changes

As the title of the PR suggests, this sets up default users (and roles for said users) using Spring Security and in-memory authentication.

We now have 3 pre-defined users (and roles) for users to login as:

- Editor
- Reviewer
- Submitter

> The username and password are the individual users’ respective roles, i.e., the to login as an editor, do: `username: editor`, `password: editor`

## Types of changes

> What types of changes does your code introduce?
<!-- Put an `x` in the boxes that apply -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code -->
- [x] The title is described the contents of the PR
- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have moved issue to the “Need review” columns of projects

## Tasks completed

__TODO__: Fill this in

## Tests performed

See integration tests in change-set

## Known issues

N/A

Closes #24

## Screenshots (if applicable)

N/A